### PR TITLE
disable building of a zipped egg file

### DIFF
--- a/patches/zip_safe-false.patch
+++ b/patches/zip_safe-false.patch
@@ -1,0 +1,9 @@
+diff -u -ur MySQL-python-1.2.3.orig/setup.py MySQL-python-1.2.3/setup.py
+--- MySQL-python-1.2.3.orig/setup.py	2015-09-15 10:59:03.669021612 -0700
++++ MySQL-python-1.2.3/setup.py	2015-09-15 10:59:15.537132442 -0700
+@@ -15,4 +15,5 @@
+ metadata, options = get_config()
+ metadata['ext_modules'] = [Extension(sources=['_mysql.c'], **options)]
+ metadata['long_description'] = metadata['long_description'].replace(r'\n', '')
++metadata['zip_safe'] = False
+ setup(**metadata)


### PR DESCRIPTION
setuptools 5.8 (and possibly later versions) is not fully safe in how it
handles concurrent usage of the egg cache.  This has been causing
intermittent test failures in the db package when multiple tests attempt
unzip `MySQL_python-1.2.3-py2.7-linux-x86_64.egg` into the egg cache at
the same time.

Eg.:

```
The following error occurred while trying to extract file(s) to the
Python egg
cache:

  [Errno 17] File exists: '/home/vagrant/.python-eggs'

The Python egg cache directory is currently set to:

  /home/vagrant/.python-eggs

Perhaps your account does not have write access to this directory?  You
can
change the cache directory by setting the PYTHON_EGG_CACHE environment
variable to point to an accessible directory.

The following tests failed:
/home/vagrant/stack/EupsBuildDir/Linux64/db-10.1+41/db-10.1+41/tests/.tests/testDbRemote.py.failed
1 tests failed
scons: *** [checkTestStatus] Error 1
scons: building terminated because of errors.
+ exit -4
eups distrib: Failed to build db-10.1+41.eupspkg: Command:
        source /home/vagrant/stack/eups/bin/setups.sh; export
EUPS_PATH=/home/vagrant/stack;
(/home/vagrant/stack/EupsBuildDir/Linux64/db-10.1+41/build.sh) >>
/home/vagrant/stack/EupsBuildDir/Linux64/db-10.1+41/build.log 2>&1
4>/home/vagrant/stack/EupsBuildDir/Linux64/db-10.1+41/build.msg
exited with code 252
```
